### PR TITLE
MU Move – Step 1: Make plugins safe

### DIFF
--- a/plugins/vaultpress/vaultpress.php
+++ b/plugins/vaultpress/vaultpress.php
@@ -11,6 +11,9 @@
  * Domain Path: /languages/
  */
 
+if ( class_exists( 'VaultPress' ) ) {
+	return;
+
 // don't call the file directly
 if ( !defined( 'ABSPATH' ) )
 	return;
@@ -2370,3 +2373,4 @@ require_once( dirname( __FILE__ ) . '/class.vaultpress-hotfixes.php' );
 $hotfixes = new VaultPress_Hotfixes();
 
 include_once( dirname( __FILE__ ) . '/cron-tasks.php' );
+} // if ( class_exists( 'VaultPress' ) ) {


### PR DESCRIPTION
This PR makes VaultPress, such that we can (temporarily) simultaneously run a copy of each in MU plugins and as an active plugin.
